### PR TITLE
Small fix in README.md, getMonth() is 0 indexed

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ $('#container').feeds({
 
         // Inside the callback 'this' corresponds to the entry being processed
         var date = new Date(this.publishedDate);
-        var pieces = [date.getDate(), date.getMonth(), date.getFullYear()]
+        var pieces = [date.getDate(), date.getMonth() + 1, date.getFullYear()]
         this.publishedDate = pieces.join('-');
     }
 });


### PR DESCRIPTION
Small fix in the format example. The getMonth() method returns a 0-indexed value. This should be corrected with an increment to display the correct month number.
